### PR TITLE
Update default resampling behaviour to match base package

### DIFF
--- a/src/growth-firestarr.R
+++ b/src/growth-firestarr.R
@@ -135,8 +135,8 @@ if(isDatasheetEmpty(BatchOption)) {
 }
 
 if(isDatasheetEmpty(ResampleOption)) {
-  updateRunLog("No Minimum Fire Size chosen.\nDefaulting to a Minimum Fire Size of 1ha.\nPlease see the Fire Resampling Options table for more details.", type = "info")
-  ResampleOption[1,] <- c(1,0)
+  updateRunLog("No Minimum Fire Size chosen.\nDefaulting to a Minimum Fire Size of 0ha and with no extra fires. \nPlease see the Fire Resampling Options table for more details.", type = "info")
+  ResampleOption[1,] <- c(0,0)
   saveDatasheet(myScenario, ResampleOption, "burnP3Plus_FireResampleOption")
 }
 


### PR DESCRIPTION
Align default behaviour with https://github.com/BurnP3/BurnP3Plus/pull/64 .

This is only ever really used when the user is building their own deterministic inputs, but still best to keep them in step with the base package.